### PR TITLE
Add the Mir datasheet to the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
         <div class="col-7">
           <h1>The fast, open and secure display server for any device</h1>
           <p>Whether you want an information kiosk, digital signage display, in-car entertainment stack, or home automation interface, Mir on Ubuntu is your fastest path to deployment.</p>
+          <p><a href="https://assets.ubuntu.com/v1/fc86ee59-canonical-mir-datasheet-2018-09-14.pdf" class="p-button--positive"><span class="p-link--external">Get the Mir datasheet</a></a></p>
         </div>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
         <div class="col-7">
           <h1>The fast, open and secure display server for any device</h1>
           <p>Whether you want an information kiosk, digital signage display, in-car entertainment stack, or home automation interface, Mir on Ubuntu is your fastest path to deployment.</p>
-          <p><a href="https://assets.ubuntu.com/v1/fc86ee59-canonical-mir-datasheet-2018-09-14.pdf" class="p-button--positive"><span class="p-link--external">Get the Mir datasheet</a></a></p>
+          <p><a href="https://assets.ubuntu.com/v1/fc86ee59-canonical-mir-datasheet-2018-09-14.pdf" class="p-button--positive"><span class="p-link--external">Get the Mir datasheet</span></a></p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Done
Added the Mir datasheet to the homepage hero

## QA
- Pull the code
- Run `./run`
- Visit the homepage
- Check that the new button matches the [copy doc](https://docs.google.com/document/d/1wqmWPx4TJ_oJoFt4gBOg4trYMIAsugMYtHGXzYJx8kc/edit?ts=5b87c34a)

Fixes https://github.com/ubuntudesign/web-squad/issues/795