### PR TITLE
Add copy doc link to meta data

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-
+  <meta name="copydoc" content="https://docs.google.com/document/d/1wqmWPx4TJ_oJoFt4gBOg4trYMIAsugMYtHGXzYJx8kc/edit">
+  
   <title>Mir display server - The fast, open and secure display server for any device</title>
 
   <!-- Google Tag Manager -->


### PR DESCRIPTION
Fixes #33

Adds link to copydoc.

### QA
- ./run or https://mir-server-io-canonical-websites-pr-40.run.demo.haus/
- have a copy doc extension installed (version to support mir-server.io 1.2.1, or older for localhost/demo)
- go to home page
- copy doc extension should be visible on the bottom of the page

<img width="1088" alt="Screenshot 2019-03-12 at 14 59 37" src="https://user-images.githubusercontent.com/83575/54205872-7dc17a80-44d7-11e9-8fb7-2ef87397245b.png">

